### PR TITLE
Feature/accept or decline a request

### DIFF
--- a/backend/internal/handler/followsuggestions_test.go
+++ b/backend/internal/handler/followsuggestions_test.go
@@ -1,3 +1,9 @@
+// followsuggestions_test.go
+//
+// This test file verifies the GetFollowSuggestions handler.
+// It ensures the handler returns HTTP 200 when a user is present in the context and the test database is properly set up.
+// The test sets up in-memory users and followers tables and injects a mock user into the request context.
+
 package handler
 
 import (

--- a/backend/internal/handler/followsuggestions_test.go
+++ b/backend/internal/handler/followsuggestions_test.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ctxpkg "backend/internal/context"
+	"backend/internal/model"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestGetFollowSuggestions_WithUserInContext(t *testing.T) {
+	db, _ := sql.Open("sqlite3", ":memory:")
+	// Create mock tables
+	db.Exec(`CREATE TABLE users (id TEXT PRIMARY KEY, fname TEXT, lname TEXT, imgurl TEXT, profileVisibility TEXT)`)
+	db.Exec(`CREATE TABLE followers (follower_id TEXT, followed_id TEXT, status TEXT)`)
+	db.Exec(`INSERT INTO users (id, fname, lname, imgurl, profileVisibility) VALUES ('test-user', 'Test', 'User', '', 'public')`)
+
+	// Create a request and inject a user into the context
+	req := httptest.NewRequest(http.MethodGet, "/api/users/available", nil)
+	mockUser := &model.User{ID: "test-user"}
+	ctx := ctxpkg.WithUser(req.Context(), mockUser)
+	req = req.WithContext(ctx)
+
+	recorder := httptest.NewRecorder()
+	handler := GetFollowSuggestions(db)
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", recorder.Code)
+	}
+}

--- a/backend/internal/handler/folowers.go
+++ b/backend/internal/handler/folowers.go
@@ -91,7 +91,7 @@ func AcceptFollowRequest(db *sql.DB) http.HandlerFunc {
 		}
 
 		// get userID from context (this is the user accepting the request)
-		currentUserID := context.MustGetSessionID(r.Context())
+		currentUserID := context.MustGetUser(r.Context()).ID
 
 		var request struct {
 			FollowerID string `json:"followerId"`
@@ -150,7 +150,7 @@ func DeclineFollowRequest(db *sql.DB) http.HandlerFunc {
 		}
 
 		// get userID from context (this is the user declining the request)
-		currentUserID := context.MustGetSessionID(r.Context())
+		currentUserID := context.MustGetUser(r.Context()).ID
 
 		var request struct {
 			FollowerID string `json:"followerId"`

--- a/backend/internal/handler/folowers.go
+++ b/backend/internal/handler/folowers.go
@@ -79,3 +79,120 @@ func FollowUser(db *sql.DB) http.HandlerFunc {
 		json.NewEncoder(w).Encode(map[string]string{"message": message})
 	}
 }
+
+// AcceptFollowRequest allows the recipient of a follow request to accept it.
+// Only the user who is being followed (the recipient) can accept a pending follow request.
+// The function checks that the request exists and is pending, then updates its status to 'accepted'.
+func AcceptFollowRequest(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// get userID from context (this is the user accepting the request)
+		currentUserID := context.MustGetSessionID(r.Context())
+
+		var request struct {
+			FollowerID string `json:"followerId"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		// Verify that the follow request exists and is pending
+		var exists bool
+		err := db.QueryRow(`
+			SELECT EXISTS(
+				SELECT 1 FROM followers 
+				WHERE follower_id = ? AND followed_id = ? AND status = 'pending'
+			)`, request.FollowerID, currentUserID).Scan(&exists)
+
+		if err != nil {
+			log.Printf("Error checking follow request: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		if !exists {
+			http.Error(w, "Follow request not found or already processed", http.StatusNotFound)
+			return
+		}
+
+		// Update the follow request status to accepted
+		_, err = db.Exec(`
+			UPDATE followers 
+			SET status = 'accepted' 
+			WHERE follower_id = ? AND followed_id = ? AND status = 'pending'
+		`, request.FollowerID, currentUserID)
+
+		if err != nil {
+			log.Printf("Error accepting follow request: %v", err)
+			http.Error(w, "Failed to accept follow request", http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Follow request accepted"})
+	}
+}
+
+// DeclineFollowRequest allows the recipient of a follow request to decline it.
+// Only the user who is being followed (the recipient) can decline a pending follow request.
+// The function checks that the request exists and is pending, then deletes it from the database.
+func DeclineFollowRequest(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// get userID from context (this is the user declining the request)
+		currentUserID := context.MustGetSessionID(r.Context())
+
+		var request struct {
+			FollowerID string `json:"followerId"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		// Verify that the follow request exists and is pending
+		var exists bool
+		err := db.QueryRow(`
+			SELECT EXISTS(
+				SELECT 1 FROM followers 
+				WHERE follower_id = ? AND followed_id = ? AND status = 'pending'
+			)`, request.FollowerID, currentUserID).Scan(&exists)
+
+		if err != nil {
+			log.Printf("Error checking follow request: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		if !exists {
+			http.Error(w, "Follow request not found or already processed", http.StatusNotFound)
+			return
+		}
+
+		// Delete the follow request
+		_, err = db.Exec(`
+			DELETE FROM followers 
+			WHERE follower_id = ? AND followed_id = ? AND status = 'pending'
+		`, request.FollowerID, currentUserID)
+
+		if err != nil {
+			log.Printf("Error declining follow request: %v", err)
+			http.Error(w, "Failed to decline follow request", http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Follow request declined"})
+	}
+}

--- a/backend/internal/handler/folowers_test.go
+++ b/backend/internal/handler/folowers_test.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"bytes"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ctxpkg "backend/internal/context"
+	"backend/internal/model"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestFollowUser_InvalidMethod(t *testing.T) {
+	db, _ := sql.Open("sqlite3", ":memory:")
+	req := httptest.NewRequest(http.MethodGet, "/api/users/follow", nil)
+	// Inject mock user into context
+	mockUser := &model.User{ID: "test-user"}
+	ctx := ctxpkg.WithUser(req.Context(), mockUser)
+	req = req.WithContext(ctx)
+	recorder := httptest.NewRecorder()
+	handler := FollowUser(db)
+	handler.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", recorder.Code)
+	}
+}
+
+func TestAcceptFollowRequest_InvalidMethod(t *testing.T) {
+	db, _ := sql.Open("sqlite3", ":memory:")
+	req := httptest.NewRequest(http.MethodGet, "/api/follow/accept", nil)
+	mockUser := &model.User{ID: "test-user"}
+	ctx := ctxpkg.WithUser(req.Context(), mockUser)
+	req = req.WithContext(ctx)
+	recorder := httptest.NewRecorder()
+	handler := AcceptFollowRequest(db)
+	handler.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", recorder.Code)
+	}
+}
+
+func TestDeclineFollowRequest_InvalidMethod(t *testing.T) {
+	db, _ := sql.Open("sqlite3", ":memory:")
+	req := httptest.NewRequest(http.MethodGet, "/api/follow/decline", nil)
+	mockUser := &model.User{ID: "test-user"}
+	ctx := ctxpkg.WithUser(req.Context(), mockUser)
+	req = req.WithContext(ctx)
+	recorder := httptest.NewRecorder()
+	handler := DeclineFollowRequest(db)
+	handler.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", recorder.Code)
+	}
+}
+
+func TestFollowUser_InvalidBody(t *testing.T) {
+	db, _ := sql.Open("sqlite3", ":memory:")
+	req := httptest.NewRequest(http.MethodPost, "/api/users/follow", bytes.NewBuffer([]byte("notjson")))
+	mockUser := &model.User{ID: "test-user"}
+	ctx := ctxpkg.WithUser(req.Context(), mockUser)
+	req = req.WithContext(ctx)
+	recorder := httptest.NewRecorder()
+	handler := FollowUser(db)
+	handler.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", recorder.Code)
+	}
+}

--- a/backend/internal/handler/folowers_test.go
+++ b/backend/internal/handler/folowers_test.go
@@ -1,3 +1,9 @@
+// folowers_test.go
+//
+// This test file covers basic validation for the follow, accept, and decline follow request handlers.
+// It checks that the handlers correctly handle invalid HTTP methods and invalid request bodies,
+// and that they expect a user to be present in the request context (as set by authentication middleware).
+
 package handler
 
 import (

--- a/backend/internal/middlewares/auth.go
+++ b/backend/internal/middlewares/auth.go
@@ -77,7 +77,7 @@ func AuthMiddleware(db *sql.DB, next http.HandlerFunc) http.HandlerFunc {
 
 		// Add user and session ID to context
 		ctx := context.WithUser(r.Context(), modelUser)
-		ctx = context.WithSessionID(ctx, sessionID)
+		ctx = context.WithSessionID(ctx, session.UserID)
 
 		// Continue with the request
 		next.ServeHTTP(w, r.WithContext(ctx))

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -30,4 +30,6 @@ func RegisterRoutes(db *sql.DB) {
 	http.Handle("/api/dashboard", middlewares.AuthMiddleware(db, handler.DashboardHandler))
 	http.HandleFunc("/api/users/available", middlewares.AuthMiddleware(db, handler.GetFollowSuggestions(db)))
 	http.HandleFunc("/api/users/follow", middlewares.AuthMiddleware(db, handler.FollowUser(db)))
+	http.HandleFunc("/api/follow/accept", middlewares.AuthMiddleware(db, handler.AcceptFollowRequest(db)))
+	http.HandleFunc("/api/follow/decline", middlewares.AuthMiddleware(db, handler.DeclineFollowRequest(db)))
 }


### PR DESCRIPTION
### New Features:

- Added AcceptFollowRequest handler: Allows the recipient of a follow request to accept it, updating the request status to accepted.
- Added DeclineFollowRequest handler: Allows the recipient to decline a pending follow request, removing it from the database.

**Security & Correctness:**
- Only the user who is being followed (the recipient) can accept or decline a follow request.
- Handlers verify that the request exists and is in the correct state before performing any action.

**Documentation:**
- Added descriptive comments above both AcceptFollowRequest and DeclineFollowRequest functions to explain their purpose and usage.

**Test**
Tested with curl command.